### PR TITLE
Updated the project to net-5

### DIFF
--- a/eShopModernizedNTier/src/eShopWinForms/eShopWinForms.csproj
+++ b/eShopModernizedNTier/src/eShopWinForms/eShopWinForms.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -21,10 +21,10 @@
   <ItemGroup>
     <PackageReference Include="EntityFramework" Version="6.4.4" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="System.ServiceModel.Duplex" Version="4.7.0" />
-    <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.7.0" />
-    <PackageReference Include="System.ServiceModel.Security" Version="4.7.0" />
+    <PackageReference Include="System.ServiceModel.Duplex" Version="4.8.0" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.8.0" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.8.0" />
+    <PackageReference Include="System.ServiceModel.Security" Version="4.8.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR contains following changes :

- Updates `/eShopWinForms` app under `eShopModernizedNTier` solution.
    - Updates `eShopWinForms.csproj` file to use `net-5.0`
    - Updates following nuget packages to the latest:
        - `System.ServiceModel.Duplex`
        - `System.ServiceModel.Http`
        - `System.ServiceModel.NetTcp`
        - `System.ServiceModel.Security`