### PR TITLE
Commit to update docker file in eshopWCFService

### DIFF
--- a/eShopModernizedNTier/src/eShopWCFService/Dockerfile
+++ b/eShopModernizedNTier/src/eShopWCFService/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/wcf:4.7.2
+FROM mcr.microsoft.com/dotnet/framework/wcf:4.7.2
 EXPOSE 80
 ARG source
 WORKDIR /inetpub/wwwroot


### PR DESCRIPTION
Fix to issue #69: Updating docker file in eshopWCFService with the correct microsoft-dotnet-framework-wcf image(mcr.microsoft.com/dotnet/framework/wcf:4.7.2) to resolve build issues.